### PR TITLE
Multisig scripts may contain no signature

### DIFF
--- a/src/templates/multisig/input.js
+++ b/src/templates/multisig/input.js
@@ -12,11 +12,12 @@ function partialSignature (value) {
 
 function check (script, allowIncomplete) {
   var chunks = bscript.decompile(script)
-  if (chunks.length < 2) return false
+  if (allowIncomplete && chunks.length < 1) return false
+  if (!allowIncomplete && chunks.length < 2) return false
   if (chunks[0] !== OPS.OP_0) return false
 
   if (allowIncomplete) {
-    return chunks.slice(1).every(partialSignature)
+    return chunks.every(partialSignature)
   }
 
   return chunks.slice(1).every(bscript.isCanonicalSignature)


### PR DESCRIPTION
Multisign wallets may contain 0 signatures. The looks following

Redeem script

`49004752210320907b02d0fef66f163999176ca361d710645408e6beb8d8b943c1d80eeb59f221032fa263b8b88c650febc25e865e7fd88d45c2bd2e321b1d970a8edf776664533152ae`

Explained

```
49 - ScriptSig length
00 - so called multisig script bug. More details in Understanding Bitcoin
47 - redeem script length
Redeem script
52210320907b02d0fef66f163999176ca361d710645408e6beb8d8b943c1d80eeb59f221032fa263b8b88c650febc25e865e7fd88d45c2bd2e321b1d970a8edf776664533152ae
```